### PR TITLE
fixes issue https://github.com/deton/tcvime/issues/3

### DIFF
--- a/autoload/tcvime.vim
+++ b/autoload/tcvime.vim
@@ -1464,7 +1464,7 @@ endfunction
 " SelectWindowByName(name)
 "   Acitvate selected window by a:name.
 function! s:SelectWindowByName(name)
-  let num = bufwinnr('^' . a:name . '$')
+  let num = bufwinnr(a:name)
   if num > 0 && num != winnr()
     execute num . 'wincmd w'
   endif


### PR DESCRIPTION
Mac(と恐らくLinuxも)環境で **TcvimeHelp** バッファが追加して作られ続けてしまう問題があるため、以前のbufwinnrのargumentにお戻し願うものです。
